### PR TITLE
Use Fetch API instead of XMLHttpRequest

### DIFF
--- a/STEMTrivial/package.json
+++ b/STEMTrivial/package.json
@@ -59,5 +59,8 @@
     "devDependencies": {
       "typescript": "npm:typescript@^2.0.7"
     }
+  },
+  "scripts": {
+    "start": "au run --watch"
   }
 }

--- a/STEMTrivial/src/services/question-service.ts
+++ b/STEMTrivial/src/services/question-service.ts
@@ -2,21 +2,17 @@ import { Question } from './../models/question';
 import { inject, NewInstance } from 'aurelia-framework';
 
 @inject(NewInstance.of(Question))
-export class QuestionService { 
+export class QuestionService {
     constructor() {
     }
 
-    getQuestions(objectApp,callback) {   
-      var xobj = new XMLHttpRequest();
-      xobj.overrideMimeType("application/json");
-      xobj.open('GET', './src/resources/data/questions.json', true); 
-      xobj.onreadystatechange = function () {
-            if ((xobj.readyState == 4) && xobj.status == 200) {
-              objectApp.questions = JSON.parse(xobj.responseText);
-              callback(objectApp);
-            }
-      };
-      xobj.send(null);  
+    async getQuestions(objectApp,callback) {
+      const response: Response = await fetch('./src/resources/data/questions.json');
+      const json = await response.json();
+
+      objectApp.questions = json;
+
+      callback(objectApp);
    }
 
    getRandomQuestions(questions, totalNumberOfQuestions, amountQuestionsSelected): Question[]{
@@ -33,7 +29,7 @@ export class QuestionService {
            count++;
         }
       }while(count < amountQuestionsSelected)
-      
+
       return resultArrayQuestions;
    }
   }

--- a/STEMTrivial/src/services/question-service.ts
+++ b/STEMTrivial/src/services/question-service.ts
@@ -20,7 +20,7 @@ export class QuestionService {
       do{
         let actualNumber = Math.floor((Math.random() * totalNumberOfQuestions));
 
-        if(choosedNumbers.indexOf(actualNumber) == -1){
+        if(choosedNumbers.indexOf(actualNumber) === -1){
            choosedNumbers.push(actualNumber);
            resultArrayQuestions.push(questions[actualNumber]);
            count++;

--- a/STEMTrivial/src/services/question-service.ts
+++ b/STEMTrivial/src/services/question-service.ts
@@ -3,9 +3,6 @@ import { inject, NewInstance } from 'aurelia-framework';
 
 @inject(NewInstance.of(Question))
 export class QuestionService {
-    constructor() {
-    }
-
     async getQuestions(objectApp,callback) {
       const response: Response = await fetch('./src/resources/data/questions.json');
       const json = await response.json();


### PR DESCRIPTION
Hi there,

this change proposes to use the Fetch API -what I think- makes the service logic much more friendly to use (since `XMLHttpRequest` is the _devil_ 😄).

[Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) is a promise-based API to perform ajax requests but with a really simple and powerful interface. It is a native API (no need for external libraries) and it is now [broadly supported by major browsers](https://caniuse.com/#feat=fetch).

## Some other changes

* Since this project is already using TypeScript I have choosen [`async/await`](https://hackernoon.com/6-reasons-why-javascripts-async-await-blows-promises-away-tutorial-c7ec10518dd9) to work with promises.
* I always prefer to use `===` instead of just `==` to avoid JavaScript _quirks_ (more info [here](http://2ality.com/2011/06/javascript-equality.html))
* There is a new [`npm script`](https://docs.npmjs.com/misc/scripts) to run the project without needing to globally install _aurelia_ (npm scripts load binaries from `node_modules/`). To use it, type `npm run start` in your terminal (from within the `STEMTrivial/STEMTrivial` folder).

---

Please, feel free to reject this PR if it doesn't make sense to you or if you were not expecting these kinds of requests ☺️ 